### PR TITLE
Theme palette

### DIFF
--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -12,9 +12,9 @@
 // to match your app's branding.
 // Tip: Use the "Theme Builder" on Quasar's documentation website.
 
-$primary : #AD074D;
-$secondary : #F45899;
-$accent : #3A9492;
+$primary: #AD074D;
+$secondary: #F45899;
+$accent: #3A9492;
 
 $dark-page: #000000;
 $dark: #111827;

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -12,14 +12,14 @@
 // to match your app's branding.
 // Tip: Use the "Theme Builder" on Quasar's documentation website.
 
-$primary: #11a174;
-$secondary: #3b82f6;
-$accent: #d33c3c;
+$primary : #AD074D;
+$secondary : #F45899;
+$accent : #3A9492;
 
 $dark-page: #000000;
 $dark: #111827;
 
-$positive: #21ba45;
-$negative: #c10015;
-$info: #31ccec;
-$warning: #f2c037;
+$positive: #4caf50;
+$negative: #ff5252;
+$info: #2196f3;
+$warning: #ffc107;


### PR DESCRIPTION
Closes #6 
Actualizada a la segunda propuesta, con colores para positive, negativo, info y warning menos intensos. Dejando como intensos primario, secundario y de enfasis